### PR TITLE
feat: toggle app

### DIFF
--- a/src/launch-app.tsx
+++ b/src/launch-app.tsx
@@ -1,16 +1,34 @@
-import { LocalStorage, open } from "@raycast/api";
+import { LocalStorage, getFrontmostApplication, showHUD, closeMainWindow, popToRoot, open } from "@raycast/api";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execPromise = promisify(exec);
 
 export default async function LaunchSelectedApp() {
   try {
     const appPath = await LocalStorage.getItem<string>("selected_app_path");
 
     if (!appPath) {
+      await showHUD("No app selected. Please select an app first.");
       return;
     }
 
-    await open(appPath);
+    const frontmostApp = await getFrontmostApplication();
+    const isTargetAppFrontmost = frontmostApp.path === appPath;
 
+    if (isTargetAppFrontmost) {
+      const appName = appPath.split('/').pop()?.replace('.app', '');
+      if (appName) {
+        await execPromise(`osascript -e 'tell application "System Events" to set visible of process "${appName}" to false'`);
+      }
+    } else {
+      await open(appPath);
+    }
+
+    await closeMainWindow();
+    await popToRoot();
   } catch (error) {
-    console.error("Failed to launch app:", error);
+    console.error("Failed to toggle app:", error);
+    await showHUD("Failed to toggle application");
   }
 }


### PR DESCRIPTION
This pull request enhances the functionality of the `LaunchSelectedApp` feature by adding checks for the currently frontmost application, improving user feedback, and introducing additional utility functions. The changes aim to provide a smoother user experience when toggling or launching applications.

### Enhancements to application toggling and user feedback:

* Added functionality to check if the selected application is already the frontmost app (`getFrontmostApplication`). If it is, the app's visibility is toggled using an AppleScript command executed via `execPromise`.
* Improved user feedback by showing a HUD message when no app is selected or when an error occurs during the operation (`showHUD`).

### Code organization and utility improvements:

* Imported additional utilities, including `promisify` and `exec`, to simplify asynchronous execution of shell commands.
* Added logic to close the main window and return to the root view after launching or toggling an application (`closeMainWindow` and `popToRoot`).